### PR TITLE
Rebrand Smile Center assets to Dentomex

### DIFF
--- a/recibo.html
+++ b/recibo.html
@@ -2,7 +2,7 @@
 <html lang="es" class="<?= (format === 'pos80') ? 'pos80' : 'a4' ?>">
 <head>
   <meta charset="UTF-8" />
-  <title>Recibo Smile Center</title>
+  <title>Recibo Dentomex</title>
   <style>
     :root {
       --text: #222;
@@ -350,9 +350,9 @@
 </head>
 <body class="page-compact">
   <header>
-    <img src="https://raw.githubusercontent.com/reaperkaeru/host-pics/refs/heads/main/Smile%20Center.svg" alt="Smile Center Logo" />
+    <img src="https://raw.githubusercontent.com/reaperkaeru/host-pics/refs/heads/main/8972055a-7c1e-403a-a05e-88136a511752.jpeg" alt="Dentomex Logo" />
     <div>
-      <h1>Smile Center — Recibo de Orden</h1>
+      <h1>Dentomex — Recibo de Orden</h1>
       <p class="subtitle">Documento de referencia para el paciente y el laboratorio</p>
       <div class="header-meta">
         <span class="chip">ID: <strong style="margin-left:6px; letter-spacing:.3px;"><?= record['ID Orden'] ?></strong></span>

--- a/recibo_pos58.html
+++ b/recibo_pos58.html
@@ -28,7 +28,7 @@
   </style>
 </head>
 <body>
-  <? var logoSrc = (r && r['Logo URL']) ? r['Logo URL'] : 'https://raw.githubusercontent.com/reaperkaeru/host-pics/refs/heads/main/Smile%20Center.svg'; ?>
+  <? var logoSrc = (r && r['Logo URL']) ? r['Logo URL'] : 'https://raw.githubusercontent.com/reaperkaeru/host-pics/refs/heads/main/8972055a-7c1e-403a-a05e-88136a511752.jpeg'; ?>
   <header>
     <img src="<?= logoSrc ?>" alt="Logo" />
   </header>

--- a/sidebar.html
+++ b/sidebar.html
@@ -1314,10 +1314,10 @@
   <header class="app-header">
     <div class="app-header-inner">
       <div class="hero-logo-wrapper">
-        <img src="https://raw.githubusercontent.com/reaperkaeru/host-pics/refs/heads/main/smilecenterblanco.svg" alt="Smile Center Logo" class="logo">
+        <img src="https://raw.githubusercontent.com/reaperkaeru/host-pics/refs/heads/main/8972055a-7c1e-403a-a05e-88136a511752.jpeg" alt="Dentomex Logo" class="logo">
       </div>
       <div class="hero-text">
-        <h1 class="hero-title">Smile Center</h1>
+        <h1 class="hero-title">Dentomex</h1>
         <p class="hero-subtitle">Orden de laboratorio dental · Seguimiento preciso de cada pieza y tratamiento.</p>
       </div>
     </div>
@@ -1355,13 +1355,6 @@
           <div>
             <label for="dentistNumero">Número de contacto</label>
             <input type="tel" id="dentistNumero" name="dentistNumero" placeholder="+52 000 000 0000" autocomplete="tel">
-          </div>
-          <div>
-            <label for="tipoCliente">Tipo de cliente</label>
-            <select id="tipoCliente" name="tipoCliente">
-              <option value="Maquila">Maquila</option>
-              <option value="Dentista">Dentista</option>
-            </select>
           </div>
         </div>
         <div class="field">
@@ -2890,7 +2883,6 @@
           dentistNombre: (document.getElementById('dentistNombre')?.value || '').trim(),
           dentistApellido: (document.getElementById('dentistApellido')?.value || '').trim(),
           dentistNumero: (document.getElementById('dentistNumero')?.value || '').trim(),
-          tipoCliente: (document.getElementById('tipoCliente')?.value || '').trim(),
           pacienteNombre,
           doctorNombre,
           doctorTel,


### PR DESCRIPTION
## Summary
- update the primary receipt to use the Dentomex title, header logo, and alt text
- refresh the sidebar hero branding to Dentomex and remove the unused client type field and references
- point the 58mm receipt logo fallback to the new Dentomex asset

## Testing
- not run (HTML updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e05ae367c88325886bafad9ca35d31